### PR TITLE
LC-1629 CI: Add a doc generation job for live-capture

### DIFF
--- a/.yamato/package-documentation.yml
+++ b/.yamato/package-documentation.yml
@@ -1,0 +1,14 @@
+generate_documentation:
+  name : Generate documentation for Live Capture
+  agent:
+    type: Unity::VM::osx
+    image: package-ci/macos-12:v4
+    flavor: m1.mac
+  commands:
+    - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.3.0
+      variables:
+        EDITOR_VERSION: trunk
+        PACKAGE_NAME: com.unity.live-capture
+        PACKAGE_PATH: Packages/com.unity.live-capture
+        #Treat doc build warnings as errors
+        WARNINGS_AS_ERRORS: false


### PR DESCRIPTION
## Purpose of this PR:
Live-capture packages misses a doc generation job, need to add one using doc generation birck.

**JIRA ticket:**
[LC-1629](https://jira.unity3d.com/browse/LC-1629) CI: Add a doc generation job for live-capture