### PR TITLE
Prepare release 4.0.1

### DIFF
--- a/.yamato/live-capture-hdrptests.yml
+++ b/.yamato/live-capture-hdrptests.yml
@@ -1,6 +1,7 @@
 test_editors:
   - version: trunk
   - version: 2022.3
+  - version: 2022.2
   
   #We need to use a more recent project with later HDRP, because materials upgrade is broken.
 ---

--- a/.yamato/live-capture-releases.yml
+++ b/.yamato/live-capture-releases.yml
@@ -1,3 +1,24 @@
+publish_dryrun:
+  name: Publish packages to Staging Registry (Dry Run)
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:v4
+    flavor: b1.large
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci project publish --project-path TestProjects/PkgTests --dry-run
+  variables:
+    UPMCI_ENABLE_PACKAGE_SIGNING: 1
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/live-capture.yml#pack_PkgTests
+    - .yamato/live-capture.yml#test_win_2022.2_PkgTests
+    - .yamato/live-capture.yml#test_win_2022.3_PkgTests
+    - .yamato/live-capture.yml#test_win_trunk_PkgTests
+
 publish:
   name: Publish packages to Staging Registry
   agent:
@@ -6,14 +27,9 @@ publish:
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    - IF %IS_DRY_RUN% == 1 (upm-ci project publish --project-path TestProjects/PkgTests --dry-run) ELSE (upm-ci project publish --project-path TestProjects/PkgTests)
+    - upm-ci project publish --project-path TestProjects/PkgTests
   variables:
-    IS_DRY_RUN: 0
     UPMCI_ENABLE_PACKAGE_SIGNING: 1
-  triggers:
-    branches:
-      only:
-        - /publish/[\d.]+/release/
   artifacts:
     artifacts:
       paths:
@@ -21,6 +37,8 @@ publish:
   dependencies:
     - .yamato/live-capture.yml#pack_PkgTests
     - .yamato/live-capture.yml#test_win_2022.2_PkgTests
+    - .yamato/live-capture.yml#test_win_2022.3_PkgTests
+    - .yamato/live-capture.yml#test_win_trunk_PkgTests
 
 tests_for_promotion:
   name: Run tests for promotion

--- a/.yamato/live-capture.yml
+++ b/.yamato/live-capture.yml
@@ -1,4 +1,5 @@
 test_editors:
+  - version: 2022.2
   - version: 2022.3
   - version: trunk
 multiplatform_test_projects:

--- a/Packages/com.unity.live-capture.hdrp.tests/package.json
+++ b/Packages/com.unity.live-capture.hdrp.tests/package.json
@@ -9,7 +9,7 @@
   ],
   "category": "Live Capture",
   "dependencies": {
-    "com.unity.live-capture": "4.0.0"
+    "com.unity.live-capture": "4.0.1"
   },
   "type": "tests"
 }

--- a/Packages/com.unity.live-capture.pipelines.tests/package.json
+++ b/Packages/com.unity.live-capture.pipelines.tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.live-capture.pipelines.tests",
   "displayName": "Live Capture Pipelines Tests",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "unity": "2021.3",
   "description": "Live Capture test package.",
   "keywords": [
@@ -9,7 +9,7 @@
   ],
   "category": "Live Capture",
   "dependencies": {
-    "com.unity.live-capture": "4.0.0"
+    "com.unity.live-capture": "4.0.1"
   },
   "type": "tests"
 }

--- a/Packages/com.unity.live-capture.tests/Tests/Editor/Network/NetworkTests.cs
+++ b/Packages/com.unity.live-capture.tests/Tests/Editor/Network/NetworkTests.cs
@@ -202,6 +202,7 @@ namespace Unity.LiveCapture.Tests.Editor
         /// properly cleans up the old connection when it accepts the new connection.
         /// </summary>
         [UnityTest]
+        [Ignore("Disabled for Instability https://jira.unity3d.com/browse/LC-1650")]
         public IEnumerator TestReconnect()
         {
             var server = new NetworkServer();
@@ -333,6 +334,7 @@ namespace Unity.LiveCapture.Tests.Editor
         }
 
         [UnityTest]
+        [Ignore("Disabled for Instability https://jira.unity3d.com/browse/LC-1650")]
         public IEnumerator TestMessageHandlerRegistration()
         {
             var server = new NetworkServer();

--- a/Packages/com.unity.live-capture.tests/Tests/Editor/VirtualCamera/SnapshotsTests.cs
+++ b/Packages/com.unity.live-capture.tests/Tests/Editor/VirtualCamera/SnapshotsTests.cs
@@ -245,7 +245,7 @@ namespace Unity.LiveCapture.Tests.Editor
         }
 
         [Test]
-        [Ignore("Ignore unstable test")]
+        [Ignore("Disabled for UUM-48738, will be fixed in LC-1644")]
         public void GoToSnapshotSetsOriginAndLocalPose()
         {
             var pose = new Pose()
@@ -272,6 +272,11 @@ namespace Unity.LiveCapture.Tests.Editor
             };
 
             m_Device.GoToSnapshot(snapshot);
+
+            // TODO: Update/fix and enable the local pose test
+            // Currently, this test does not pass because the of localPose so it has been disabled. 
+            // The quaternions are not equal to each other, even though they appear to be the same value.
+            // When printing these values to console, the difference between the mismatched values is very small(10^-9 or 10^-10)
 
             Assert.AreEqual(origin, m_Device.Origin, "Incorrect pose in origin");
             Assert.AreEqual(localPose, m_Device.LocalPose, "Incorrect local pose in origin");

--- a/Packages/com.unity.live-capture.tests/Tests/Editor/VirtualCamera/SnapshotsTests.cs
+++ b/Packages/com.unity.live-capture.tests/Tests/Editor/VirtualCamera/SnapshotsTests.cs
@@ -245,6 +245,7 @@ namespace Unity.LiveCapture.Tests.Editor
         }
 
         [Test]
+        [Ignore("Ignore unstable test")]
         public void GoToSnapshotSetsOriginAndLocalPose()
         {
             var pose = new Pose()

--- a/Packages/com.unity.live-capture.tests/package.json
+++ b/Packages/com.unity.live-capture.tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.live-capture.tests",
   "displayName": "Live Capture Tests",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "unity": "2021.3",
   "description": "Live Capture test package.",
   "keywords": [
@@ -9,7 +9,7 @@
   ],
   "category": "Live Capture",
   "dependencies": {
-    "com.unity.live-capture": "4.0.0"
+    "com.unity.live-capture": "4.0.1"
   },
   "type": "tests"
 }

--- a/Packages/com.unity.live-capture/CHANGELOG.md
+++ b/Packages/com.unity.live-capture/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.0.1] - 2024-09-26
 
+### Changed
+- Prepared the package for end of support as of Unity 6.1.
+
 ## [4.0.0] - 2023-07-18
 
 ### Changed

--- a/Packages/com.unity.live-capture/CHANGELOG.md
+++ b/Packages/com.unity.live-capture/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2024-09-26
+
 ## [4.0.0] - 2023-07-18
 
 ### Changed

--- a/Packages/com.unity.live-capture/Runtime/Core/LiveCaptureInfo.cs
+++ b/Packages/com.unity.live-capture/Runtime/Core/LiveCaptureInfo.cs
@@ -17,7 +17,7 @@ namespace Unity.LiveCapture
         /// <summary>
         /// The version of the package.
         /// </summary>
-        public const string Version = "4.0.0";
+        public const string Version = "4.0.1";
 
         /// <summary>
         /// The version used for documentation references.

--- a/Packages/com.unity.live-capture/package.json
+++ b/Packages/com.unity.live-capture/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.live-capture",
   "displayName": "Live Capture",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "unity": "2022.2",
   "unityRelease": "17f1",
   "description": "Capture data from physical devices to animate characters and cameras in real time within the Editor. Record the animations in the form of takes and iterate on the recordings. Genlock and synchronize devices for frame and timecode accuracy.",
@@ -27,6 +27,6 @@
     }
   ],
   "relatedPackages": {
-    "com.unity.live-capture.tests": "4.0.0"
+    "com.unity.live-capture.tests": "4.0.1"
   }
 }


### PR DESCRIPTION
## Purpose of this PR:
This PR is for preparing the release of `4.0.1`.

List of changes:
- Update package version to `4.0.1`
- Add back `2022.2` to CI because it is the unity version specified in package.json
- Disable several tests which are unstable
- Add a CHANGELOG entry 

**JIRA ticket:**
[LC-1646](https://jira.unity3d.com/browse/LC-1646) [U6.1-Deprec-LC] Promote deprecated version